### PR TITLE
Added Fast Platform Switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Thanks to all the [contributors](https://github.com/ryannielson/awesome-unity/gr
 * [UniMerge (Paid)](https://www.assetstore.unity3d.com/en/#!/content/9733) - Editor extension for merging scenes and prefabs, also integrates with VCS.
 * [UniRx](https://github.com/neuecc/UniRx) - UniRx (Reactive Extensions for Unity) is a reimplementation of the .NET Reactive Extensions. Rx cures the "asynchronous blues" without async/await.
 * [UnityToolbag](https://github.com/nickgravelyn/unitytoolbag) - Collection of miscellaneous open source scripts and helpers for Unity 5.0.
+* [Fast Platform Switch (Paid)](https://www.assetstore.unity3d.com/en/#!/content/11134) - Very fast switch between target platforms by caching them.
 
 ## Visual Scripting
 


### PR DESCRIPTION
Switching between platforms on Unity is pretty slow, when developing for example on iOS and Android, switching between targets takes longer and longer as the project's assets grow.
Fast Platform Switch caches the modified assets state to make switching between targets pretty fast.
It's a must have if you are targeting more than one platform