### PR TITLE
Adding UnityTiled to 2D section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Thanks to all the [contributors](https://github.com/ryannielson/awesome-unity/gr
 * [Ferr2D Terrain Tool (Paid)](https://www.assetstore.unity3d.com/en/#!/content/11653) - Quickly create handcrafted 2D landscapes and levels.
 * [Pixel Camera 2D](https://github.com/RyanNielson/PixelCamera2D) - A simple pixel perfect camera with scaling options for 2D Games.
 * [Spine (Paid)](http://esotericsoftware.com) - A skeletal animation editor with a Unity library.
+* [UnityTiled](https://github.com/nickgravelyn/UnityTiled) - An importer for [Tiled](http://www.mapeditor.org) maps.
 
 ## AI
 


### PR DESCRIPTION
Adding a link to my UnityTiled project. I'm aware of [Tiled2Unity](http://www.seanba.com/tiled2unity) but that uses an external tool (GUI on Windows, command line elsewhere) which I wasn't fond of. My UnityTiled project is an entirely Unity process that allows for taking Tiled maps and building out sprites and prefabs based on the map, along with some callback systems for post-processing, such as building collision geometry or linking object references.

I haven't worked on the code in a little while (last commit was May 29), admittedly, but I made sure to put some good wiki pages describing how it all works. The asset is also totally free and open source under the MIT license so while this is sort of advertising my asset I'm not trying to sell anyone anything with it.

It's all MIT licensed and free for anyone to use.