### PR TITLE
Added ChromeAppBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Thanks to all the [contributors](https://github.com/ryannielson/awesome-unity/gr
 
 ## Utilities
 
+* [ChromeAppBuilder](https://github.com/iBicha/ChromeAppBuilder) - An editor extension for Unity3D to export games as google chrome apps.
 * [Consolation](https://github.com/mminer/consolation) - In-game debug console that displays output from `Debug.Log`.
 * [CSharpatron (Paid)](https://www.assetstore.unity3d.com/en/#!/content/20232) - Automatically convert scripts from UnityScript to C# without breaking existing game objects.
 * [SnazzyGrid (Paid)](https://www.assetstore.unity3d.com/en/#!/content/19245) - Makes it easy to manage positions of assets in the scene with easy to use snapping tools and many more features to improve the scene creation workflow.


### PR DESCRIPTION
ChromeAppBuilder
Chrome app builder is an editor extension for Unity3D to export games as google chrome apps. 
https://github.com/iBicha/ChromeAppBuilder