### PR TITLE
Add Asset Usage Finder to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Thanks to all the [contributors](https://github.com/ryannielson/awesome-unity/gr
 
 ## Utilities
 
+* [Asset Usage Finder (Paid)](https://assetstore.unity.com/packages/tools/utilities/asset-usage-finder-59997) - Editor extension for finding references of assets inside project and all scene files.
 * [Consolation](https://github.com/mminer/consolation) - In-game debug console that displays output from `Debug.Log`.
 * [CSharpatron (Paid)](https://www.assetstore.unity3d.com/en/#!/content/20232) - Automatically convert scripts from UnityScript to C# without breaking existing game objects.
 * [GitHub for Unity](https://unity.github.com/) - The new GitHub for Unity extension brings the GitHub workflow and more to Unity, providing support for large files with Git LFS and file locking.


### PR DESCRIPTION
This is a great editor extension that adds an option to search for "File Usages" in the project and all scene files. (Unity only provides a "Find References in Scene" context menu option for the currently open scene.)

Paid, but the source is included and the developer is active.