### PR TITLE
Add Selection History Navigator to utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Thanks to all the [contributors](https://github.com/ryannielson/awesome-unity/gr
 * [CSharpatron (Paid)](https://www.assetstore.unity3d.com/en/#!/content/20232) - Automatically convert scripts from UnityScript to C# without breaking existing game objects.
 * [GitHub for Unity](https://unity.github.com/) - The new GitHub for Unity extension brings the GitHub workflow and more to Unity, providing support for large files with Git LFS and file locking.
 * [Scene View Bookmarks](https://github.com/mminer/scene-view-bookmarks) - Editor extension to bookmark and later recall scene views.
+* [Selection History Navigator](https://github.com/mminer/selection-history-navigator) - Editor extension to navigate between object selections.
 * [SnazzyGrid (Paid)](https://www.assetstore.unity3d.com/en/#!/content/19245) - Makes it easy to manage positions of assets in the scene with easy to use snapping tools and many more features to improve the scene creation workflow.
 * [UniMerge (Paid)](https://www.assetstore.unity3d.com/en/#!/content/9733) - Editor extension for merging scenes and prefabs, also integrates with VCS.
 * [UniRx](https://github.com/neuecc/UniRx) - UniRx (Reactive Extensions for Unity) is a reimplementation of the .NET Reactive Extensions. Rx cures the "asynchronous blues" without async/await.


### PR DESCRIPTION
This adds web browser-style Back and Forward items to the Edit > Selection menu. These allow you to quickly re-select the game object or asset that you previously had selected. It's a small utility I wrote that has since become indispensable when I'm working with Unity, so hopefully others will find it useful too.