### PR TITLE
Add Devtodev sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Thanks to all the [contributors](https://github.com/ryannielson/awesome-unity/gr
 
 ## Services
 * [Unity Analytics](https://www.assetstore.unity3d.com/en/#!/content/28120) - Provides a dashboard with metrics to help track active players, sessions, retention, and revenue.
+* [Devtodev] (https://github.com/devtodev-analytics/unity-sdk) - A full-cycle analytics solution for game developers.
 
 ## Tweening
 


### PR DESCRIPTION
devtodev (https://www.devtodev.com/) is an analytical platform developed by games industry professionals specifically for game developers. With devtodev, you can convert players into paying users, improve in-game economics, predict churn, revenue and customer lifetime value, as well as analyze and influence user behavior.