### PR TITLE
Website updated for Apex Path (Paid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Thanks to all the [contributors](https://github.com/ryannielson/awesome-unity/gr
 ## AI
 
 * [A* Pathfinding Project](http://arongranberg.com/astar/) - Lightning fast pathfinding with heavily optimized algorithms and a large feature set.
-* [Apex Path (Paid)](https://www.assetstore.unity3d.com/en/#!/content/17943) - Apex Path handles dynamic pathfinding including local avoidance steering and dynamic obstacles.
+* [Apex Path (Paid)](https://assetstore.unity.com/packages/tools/ai/apex-path-17943) - Apex Path handles dynamic pathfinding including local avoidance steering and dynamic obstacles.
+
 * [Crystal AI](https://github.com/igiagkiozis/CrystalAI) - Crystal is a fast, scalable and extensible utility based AI framework for C# and Unity.
 
 ## Augmented & Virtual Reality


### PR DESCRIPTION
When I clicked the link for the Apex Path (Paid), the website stated that the link has changed. So I changed the website link from https://www.assetstore.unity3d.com/en/#!/content/17943 to https://assetstore.unity.com/packages/tools/ai/apex-path-17943

Location: AI -> Apex Path (Paid)