### PR TITLE
Add NFTPort Unity SDK to frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Thanks to all the [contributors](https://github.com/ryannielson/awesome-unity/gr
 ## Frameworks
 
 * [Fungus](https://github.com/snozbot/fungus) - An easy to use Unity 3D library for creating illustrated Interactive Fiction games.
+* [NFTPort Unity SDK (Free/Open-Source)](https://github.com/nftport/nftport-unity) - Full suite to integrate NFTs in Unity3D with cross-chain compatibility at ultra-fast speed. 🎲
 * [StrangeIoC](http://strangeioc.github.io/strangeioc/) - Strange is a super-lightweight and highly extensible Inversion-of-Control (IoC) framework, written specifically for C# and Unity.
 * [uFrame (Paid)](https://assetstore.unity.com/packages/tools/visual-scripting/uframe-game-framework-14381) - Create maintainable games faster, better, more stable, and consistent than ever before.
 


### PR DESCRIPTION
Hi there,
Request to add [NFTPort's ](https://www.nftport.xyz/) Free and OpenSource [Unity SDK](https://github.com/nftport/nftport-unity) which offers [full suite](https://docs.nftport.xyz/docs/nftport/ZG9jOjUwMzc2NzA5-getting-started) to integrate NFTs super easily in Unity without any requirement for blockchain coding knowledge.

Thanks for considering and maintaining this awesome repo. 
Best,
sz